### PR TITLE
Add properties to Vector prototype without overriding

### DIFF
--- a/chapter-6-vector-type.js
+++ b/chapter-6-vector-type.js
@@ -3,19 +3,19 @@ function Vector(x, y) {
     this.y = y;
 }
 
-Vector.prototype = {
-    plus: function(vect) {
-        return new Vector(this.x + vect.x, this.y + vect.y);
-    },
-    minus: function(vect) {
-        return new Vector(this.x - vect.x, this.y - vect.y);
-    },
-    get length() {
+Vector.prototype.plus = function(vect) {
+    return new Vector(this.x + vect.x, this.y + vect.y);
+};
+Vector.prototype.minus = function(vect) {
+    return new Vector(this.x - vect.x, this.y - vect.y);
+};
+Object.defineProperty(Vector.prototype, 'length', {
+    get: function() {
         var x = this.x,
             y = this.y;
         return Math.sqrt(x * x + y * y);
     }
-};
+});
 
 console.log(new Vector(1, 2).plus(new Vector(2, 3)));
 // → Vector{x: 3, y: 5}


### PR DESCRIPTION
Vector inherits a default prototype from Function. It probably shouldn't be overridden.
